### PR TITLE
analyze/1 now also takes a single filename

### DIFF
--- a/src/percept2.erl
+++ b/src/percept2.erl
@@ -278,8 +278,10 @@ stop_profile() ->
     percept2_profile:stop().
 
 %%@doc Parallel analysis of trace files. See the <a href="overview-summary.html">Overview</a> page for examples.
--spec analyze(FileNames :: [file:filename()]) ->
+-spec analyze(FileNames :: file:filename() | [file:filename()]) ->
                      'ok' | {'error', any()}.
+analyze([H | _] = Filename) when not is_list(H) ->
+    analyze([Filename]);
 analyze(FileNames) ->
     case percept2_db:start(FileNames) of
 	{started, FileNameSubDBPairs} ->


### PR DESCRIPTION
percept2:analyze/1 expects a list of filenames even if you only
provide a single one. When you provide a single filename instead
of a list, you will get errors like:

  {error,"Incorrect file or malformed trace file: 47\n"}

Those are not easily identifiable as wrong input parameters.

With this commit it is now possible to supply a single filename
that is is not wrapped in a list to percept2:analyze/1.
